### PR TITLE
Adding option to toggle adding audio metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ git clone https://github.com/FallingSnow/h265ize.git && cd h265ize && npm instal
 While in the h265ize directory run `git pull`.
 
 ## Usage
-`./h265ize [-h|--help] [-d <string>] [-q <0-51>] [-m <string>] [-n <string>] [-f <string>{3}] [-g <string>] [-l <integer>] [-o] [-p] [-v] [--10bit] [--12bit] [--accurate-timestamps] [--as-preset <preset>] [--disable-upconvert] [--debug] [--video-bitrate <integer>] [--he-audio] [--force-he-audio] [--he-downmix] [--screenshots] [--delete] <file|directory>`
+`./h265ize [-h|--help] [-d <string>] [-q <0-51>] [-m <string>] [-n <string>] [-f <string>{3}] [-g <string>] [-l <integer>] [-o] [-p] [-v] [--10bit] [--12bit] [--accurate-timestamps] [--as-preset <preset>] [--disable-upconvert] [--debug] [--video-bitrate <integer>] [--he-audio] [--force-he-audio] [--he-downmix] [--no-auto-audio-titles] [--screenshots] [--delete] <file|directory>`
 
 ### Options
 > -d :Folder to output files to
@@ -96,6 +96,8 @@ While in the h265ize directory run `git pull`.
 > --he-audio :High Efficiency audio mode
 
 > --he-downmix :If there are more than 2.1 audio channels, downmix them to stereo. **`he-audio` must also be enabled**
+
+> --no-auto-audio-titles :Do not determine and add audio stream title metadata for audio streams without pre-existing title metadata.
 
 > --screenshots :Take 6 screenshots at regular intervals throughout the finished encode
 

--- a/h265ize
+++ b/h265ize
@@ -177,6 +177,12 @@ h265ize.parseOptions = function() {
                     type: 'boolean',
                     group: 'Advanced:'
                 },
+                'auto-audio-titles': {
+                    default: userSettings['auto-audio-titles'] || true,
+                    describe: 'Determine and add audio stream title metadata for audio streams without pre-existing title metadata. Use --no-auto-audio-titles to disable.',
+                    type: 'boolean',
+                    group: 'Advanced:'
+                },
                 'o': {
                     alias: 'override',
                     default: userSettings['override'] || false,
@@ -871,7 +877,7 @@ h265ize.processVideo = function(video) {
                     let normalizedLanguage = normalizeStreamLanguage(stream);
 
                     command.outputOptions('-map', stream.input + ':' + stream.index);
-                    if (!(audioTitle)) {
+                    if (!(audioTitle) && args.autoAudioTitles) {
                         let channelsFormated = stream.channels === 2 ? 'Stereo' : stream.channels % 2 ? (stream.channels - 1) + '.1 Channel' : stream.channels + '.0 Channel';
                         let newTitle = normalizedLanguage + ' ' + stream.codec_name.toUpperCase() + ((stream.profile && stream.profile !== 'unknown') ? (' ' + stream.profile) : '') + ' (' + channelsFormated + ')';
                         logger.alert('Audio does not have a title. Title set to', '"' + newTitle + '".');
@@ -955,7 +961,7 @@ h265ize.processVideo = function(video) {
                         // Handle settings a new title
                         let audioTitle = getStreamTitle(stream);
                         let normalizedLanguage = normalizeStreamLanguage(stream);
-                        if (!(audioTitle)) {
+                        if (!(audioTitle) && args.autoAudioTitles) {
                             let channelsFormated = stream.channels === 2 ? 'Stereo' : stream.channels % 2 ? (stream.channels - 1) + '.1 Channel' : stream.channels + '.0 Channel';
                             let newTitle = normalizedLanguage + ' OPUS (' + channelsFormated + ')';
                             logger.alert('Audio does not have a title. Title set to', '"' + newTitle + '".');


### PR DESCRIPTION
Adds a new toggle --auto-audio-titles (default) and --no-auto-audio-titles to toggle adding audio stream title metadata if missing from source file. Closes issue #40 