### PR TITLE
Video stream fixes

### DIFF
--- a/h265ize
+++ b/h265ize
@@ -796,8 +796,8 @@ h265ize.processVideo = function(video) {
                     videoBitDepth = 8;
 
                 if (data.streams.videoStreams.length > 1) {
-                    // TODO implement feature
-                    logger.alert('More than one video stream detected. Using the video stream with the greatest duration.');
+                    // TODO implement feature to select the stream of greatest duration
+                    logger.alert('More than one video stream detected. Using the first video stream.');
                     videoIndex = 0;
                 }
                 let videoStream = data.videoStream = data.streams.videoStreams[videoIndex];

--- a/h265ize
+++ b/h265ize
@@ -921,6 +921,16 @@ h265ize.processVideo = function(video) {
                     });
                 });
 
+                // Other video streams (mjpeg "video" images, etc.)
+                _.each(data.streams.videoStreams, function(stream, i) {
+
+                    if (data.videoStream.index != stream.index) {
+                        command.outputOptions('-c:' + stream.index, 'copy');
+                        command.outputOptions('-map', stream.input + ':' + stream.index);
+                        logger.debug('Other video stream with index', stream.index, 'mapped.');
+                    }
+                });
+
                 // Other streams (Attachments: fonts, pictures, etc.)
                 _.each(data.streams.otherStreams, function(stream, i) {
                     command.outputOptions('-map', stream.input + ':' + stream.index);

--- a/h265ize
+++ b/h265ize
@@ -633,6 +633,9 @@ h265ize.processVideo = function(video) {
         // Set subtitle codec
         command.outputOptions('-c:s', 'copy');
 
+        // Set attachments codec
+        command.outputOptions('-c:t', 'copy');
+
         let inputCounter = 0;
         let pass = 0;
 
@@ -797,7 +800,7 @@ h265ize.processVideo = function(video) {
 
                 if (data.streams.videoStreams.length > 1) {
                     // TODO implement feature to select the stream of greatest duration
-                    logger.alert('More than one video stream detected. Using the first video stream.');
+                    logger.alert('More than one video stream detected. Using the first video stream and discarding others.');
                     videoIndex = 0;
                 }
                 let videoStream = data.videoStream = data.streams.videoStreams[videoIndex];
@@ -919,16 +922,6 @@ h265ize.processVideo = function(video) {
                         language: normalizedLanguage,
                         codec: stream.codec_long_name
                     });
-                });
-
-                // Other video streams (mjpeg "video" images, etc.)
-                _.each(data.streams.videoStreams, function(stream, i) {
-
-                    if (data.videoStream.index != stream.index) {
-                        command.outputOptions('-c:' + stream.index, 'copy');
-                        command.outputOptions('-map', stream.input + ':' + stream.index);
-                        logger.debug('Other video stream with index', stream.index, 'mapped.');
-                    }
                 });
 
                 // Other streams (Attachments: fonts, pictures, etc.)


### PR DESCRIPTION
Two commits - first, correct the erroneous log output stating that the longest video stream is selected when more than one is present. Second, when there are multiple video streams, copy the ones not converted into the output. This covers cases where cover art may be stored as an mjpeg "video" stream and prevents it from being silently dropped on conversion:

```
    Stream #0:4: Video: mjpeg, yuvj444p(pc, bt470bg/unknown/unknown), 600x882, SAR 1:1 DAR 100:147, 30k fps, 1k tbr, 1k tbn, 1k tbc
    Metadata:
      FILENAME        : cover.jpg
      MIMETYPE        : image/jpeg
```