### PR TITLE
Disable all metadata operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git clone https://github.com/FallingSnow/h265ize.git && cd h265ize && npm instal
 While in the h265ize directory run `git pull`.
 
 ## Usage
-`./h265ize [-h|--help] [-d <string>] [-q <0-51>] [-m <string>] [-n <string>] [-f <string>{3}] [-g <string>] [-l <integer>] [-o] [-p] [-v] [--10bit] [--12bit] [--accurate-timestamps] [--as-preset <preset>] [--disable-upconvert] [--no-auto-subtitle-titles] [--debug] [--video-bitrate <integer>] [--he-audio] [--force-he-audio] [--he-downmix] [--no-auto-audio-titles] [--screenshots] [--delete] <file|directory>`
+`./h265ize [-h|--help] [-d <string>] [-q <0-51>] [-m <string>] [-n <string>] [-f <string>{3}] [-g <string>] [-l <integer>] [-o] [-p] [-v] [--10bit] [--12bit] [--accurate-timestamps] [--as-preset <preset>] [--disable-upconvert] [--debug] [--video-bitrate <integer>] [--he-audio] [--force-he-audio] [--he-downmix] [--disable-metadata] [--no-auto-subtitle-titles] [--no-auto-audio-titles] [--screenshots] [--delete] <file|directory>`
 
 ### Options
 > -d :Folder to output files to
@@ -93,13 +93,15 @@ While in the h265ize directory run `git pull`.
 
 > --disable-upconvert :Disable Upconvert; Stop converting Vobsub subs to srt; Only works with mkv's
 
-> --no-auto-subtitle-titles :Disable automated title generation for subtitle streams that do not have preexisting titles.
-
 > --force-he-audio :Force High Efficiency audio encoding even on lossless audio tracks
 
 > --he-audio :High Efficiency audio mode
 
 > --he-downmix :If there are more than 2.1 audio channels, downmix them to stereo. **`he-audio` must also be enabled**
+
+> --disable-metadata :Disable setting any metadata properties when reencoding. Includes --no-auto-subtitle-titles and --no-auto-audio-titles.
+
+> --no-auto-subtitle-titles :Disable automated title generation for subtitle streams that do not have preexisting titles.
 
 > --no-auto-audio-titles :Disable automated title generation for audio streams that do not have preexisting titles.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git clone https://github.com/FallingSnow/h265ize.git && cd h265ize && npm instal
 While in the h265ize directory run `git pull`.
 
 ## Usage
-`./h265ize [-h|--help] [-d <string>] [-q <0-51>] [-m <string>] [-n <string>] [-f <string>{3}] [-g <string>] [-l <integer>] [-o] [-p] [-v] [--10bit] [--12bit] [--accurate-timestamps] [--as-preset <preset>] [--disable-upconvert] [--debug] [--video-bitrate <integer>] [--he-audio] [--force-he-audio] [--he-downmix] [--no-auto-audio-titles] [--screenshots] [--delete] <file|directory>`
+`./h265ize [-h|--help] [-d <string>] [-q <0-51>] [-m <string>] [-n <string>] [-f <string>{3}] [-g <string>] [-l <integer>] [-o] [-p] [-v] [--10bit] [--12bit] [--accurate-timestamps] [--as-preset <preset>] [--disable-upconvert] [--no-auto-subtitle-titles] [--debug] [--video-bitrate <integer>] [--he-audio] [--force-he-audio] [--he-downmix] [--no-auto-audio-titles] [--screenshots] [--delete] <file|directory>`
 
 ### Options
 > -d :Folder to output files to
@@ -92,6 +92,8 @@ While in the h265ize directory run `git pull`.
 > --depth :How deap the search for files should go in subdirectories; default: 2
 
 > --disable-upconvert :Disable Upconvert; Stop converting Vobsub subs to srt; Only works with mkv's
+
+> --no-auto-subtitle-titles :Disable automated title generation for subtitle streams that do not have preexisting titles.
 
 > --force-he-audio :Force High Efficiency audio encoding even on lossless audio tracks
 

--- a/h265ize
+++ b/h265ize
@@ -217,6 +217,12 @@ h265ize.parseOptions = function() {
                     type: 'boolean',
                     group: 'Advanced:'
                 },
+                'disable-metadata': {
+                    default: userSettings['disable-metadata'] || false,
+                    describe: 'Disables setting any metadata properties when reencoding, includes --no-auto-subtitle-titles and --no-auto-audio-titles.',
+                    type: 'boolean',
+                    group: 'Advanced:'
+                },
                 'stats': {
                     default: userSettings['stats'] || false,
                     describe: 'Output a stats file containing stats for each video converted.',
@@ -927,7 +933,7 @@ h265ize.processVideo = function(video) {
                     let normalizedLanguage = normalizeStreamLanguage(stream);
 
                     command.outputOptions('-map', stream.input + ':' + stream.index);
-                    if (!(audioTitle) && args.autoAudioTitles) {
+                    if (!(audioTitle) && args.autoAudioTitles && !(args.disableMetadata)) {
                         let channelsFormated = stream.channels === 2 ? 'Stereo' : stream.channels % 2 ? (stream.channels - 1) + '.1 Channel' : stream.channels + '.0 Channel';
                         let newTitle = normalizedLanguage + ' ' + stream.codec_name.toUpperCase() + ((stream.profile && stream.profile !== 'unknown') ? (' ' + stream.profile) : '') + ' (' + channelsFormated + ')';
                         logger.alert('Audio does not have a title. Title set to', '"' + newTitle + '".');
@@ -935,7 +941,7 @@ h265ize.processVideo = function(video) {
                     }
 
                     // Set default audio
-                    if (data.defaultAudioIndex && data.defaultAudioIndex === stream.index) {
+                    if (data.defaultAudioIndex && data.defaultAudioIndex === stream.index && !(args.disableMetadata)) {
                         command.outputOptions('-metadata:s:a:' + i, 'DISPOSITION:default=1');
                     }
 
@@ -965,11 +971,15 @@ h265ize.processVideo = function(video) {
 
 
                     command.outputOptions('-map', stream.input + ':' + stream.index);
-                    if (!getStreamTitle(stream) && args.autoSubtitleTitles) {
+                    if (!getStreamTitle(stream) && args.autoSubtitleTitles && !(args.disableMetadata)) {
                         logger.alert('Subtitle does not have a title. Title set to', normalizedLanguage + '.');
                         command.outputOptions('-metadata:s:s:' + i, 'title=' + normalizedLanguage);
                     }
-                    command.outputOptions('-metadata:s:s:' + i, 'DISPOSITION:default=0');
+
+                    if (!(args.disableMetadata)) {
+                        command.outputOptions('-metadata:s:s:' + i, 'DISPOSITION:default=0');
+                    }
+
                     logger.debug('Subtitle stream with index', stream.index, 'mapped.', {
                         title: getStreamTitle(stream),
                         language: normalizedLanguage,
@@ -1013,7 +1023,7 @@ h265ize.processVideo = function(video) {
                         // Handle settings a new title
                         let audioTitle = getStreamTitle(stream);
                         let normalizedLanguage = normalizeStreamLanguage(stream);
-                        if (!(audioTitle) && args.autoAudioTitles) {
+                        if (!(audioTitle) && args.autoAudioTitles && !(args.disableMetadata)) {
                             let channelsFormated = stream.channels === 2 ? 'Stereo' : stream.channels % 2 ? (stream.channels - 1) + '.1 Channel' : stream.channels + '.0 Channel';
                             let newTitle = normalizedLanguage + ' OPUS (' + channelsFormated + ')';
                             logger.alert('Audio does not have a title. Title set to', '"' + newTitle + '".');

--- a/h265ize
+++ b/h265ize
@@ -211,6 +211,12 @@ h265ize.parseOptions = function() {
                     type: 'boolean',
                     group: 'Advanced:'
                 },
+                'auto-subtitle-titles': {
+                    default: userSettings['auto-subtitle-titles'] || true,
+                    describe: 'Determine and add subtitle stream title metadata for subtitle streams without pre-existing title metadata. Use --no-auto-subtitle-titles to disable.',
+                    type: 'boolean',
+                    group: 'Advanced:'
+                },
                 'stats': {
                     default: userSettings['stats'] || false,
                     describe: 'Output a stats file containing stats for each video converted.',
@@ -959,7 +965,7 @@ h265ize.processVideo = function(video) {
 
 
                     command.outputOptions('-map', stream.input + ':' + stream.index);
-                    if (!getStreamTitle(stream)) {
+                    if (!getStreamTitle(stream) && args.autoSubtitleTitles) {
                         logger.alert('Subtitle does not have a title. Title set to', normalizedLanguage + '.');
                         command.outputOptions('-metadata:s:s:' + i, 'title=' + normalizedLanguage);
                     }


### PR DESCRIPTION
This builds on #45, adding a `--disable-metadata` flag that stops all metadata properties from being set during the reencode, including default stream settings.