### PR TITLE
Add --nice option to lower ffmpeg process priority on *nix systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ git clone https://github.com/FallingSnow/h265ize.git && cd h265ize && npm instal
 While in the h265ize directory run `git pull`.
 
 ## Usage
-`./h265ize [-h|--help] [-d <string>] [-q <0-51>] [-m <string>] [-n <string>] [-f <string>{3}] [-g <string>] [-l <integer>] [-o] [-p] [-v] [--10bit] [--12bit] [--accurate-timestamps] [--as-preset <preset>] [--disable-upconvert] [--no-auto-subtitle-titles] [--debug] [--video-bitrate <integer>] [--he-audio] [--force-he-audio] [--he-downmix] [--no-auto-audio-titles] [--screenshots] [--delete] <file|directory>`
+`./h265ize [-h|--help] [-d <string>] [-q <0-51>] [-m <string>] [-n <string>] [-f <string>{3}] [-g <string>] [-l <integer>] [-o] [-p] [-v] [--10bit] [--12bit] [--accurate-timestamps] [--as-preset <preset>] [--disable-upconvert] [--no-auto-subtitle-titles] [--debug] [--video-bitrate <integer>] [--he-audio] [--force-he-audio] [--he-downmix] [--no-auto-audio-titles] [--nice] [--screenshots] [--delete] <file|directory>`
 
 ### Options
 > -d :Folder to output files to
@@ -108,6 +108,8 @@ While in the h265ize directory run `git pull`.
 > --stats: Creates a stats file in the destination named h265ize.csv
 
 > --video-bitrate :Sets the video bitrate, set to 0 to use qp instead of a target bitrate
+
+> --nice :Lowers the priority of the encoding process on *nix systems, but has no effect on Windows. This allows the encoder to run in the background with minimal effect on other processes.
 
 > --test: Test mode; Runs as normal, but do not encode any files
 

--- a/h265ize
+++ b/h265ize
@@ -254,6 +254,12 @@ h265ize.parseOptions = function() {
                     type: 'number',
                     group: 'Advanced:'
                 },
+                'nice': {
+                    default: userSettings['nice'] || false,
+                    describe: 'Lowers the process priority for the encoding process on *nix systems to a background task. Has no effect on Windows.',
+                    type: 'boolean',
+                    group: 'Advanced:'
+                },
                 'debug': {
                     default: userSettings['debug'] || false,
                     describe: 'Enables debug mode. Prints extra debugging information.',
@@ -676,6 +682,10 @@ h265ize.processVideo = function(video) {
                 logger: logger
             })
             .input(video);
+
+        if(args.nice) {
+            command.renice(19);
+        }
 
         // Set video codec
         command.videoCodec('libx265');


### PR DESCRIPTION
Simple option to set the nice level to 19 to put the ffmpeg encoder process to the lowest priority. Useful in running large batch conversions on non-dedicated hardware. (Eg helps prevent CPU contention and possible transcoding lag for live transcoding that may be done on a media server.)

Unfortunately, this has no effect on Windows systems.