### PR TITLE
Add hvc1 tag to codec and copy cover art for mp4 and m4v

### DIFF
--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -382,7 +382,7 @@ class Video {
             
             // add hvc1 tag to codec so it is playable by Quicktime
                 
-            command.outputOptions('-tag:v:0', 'hvc1');
+            command.outputOptions('-tag:v:'+ videoIndex, 'hvc1');
 
             // Make sure we are only attempting to use 8 bit with fallback
             // binary

--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -816,6 +816,7 @@ class Video {
                 if (stream.codec_name !== 'flac' || _self.options.forceHeAudio) {
                     _self.encoder.logger.verbose('Audio stream', colors.yellow(helpers.getStreamTitle(stream) + ' (index: ' + stream.index + ')'), 'will be encoded to HE Audio.');
                     _self.ffmpegCommand.outputOptions('-c:a:' + i, 'libopus');
+                    _self.ffmpegCommand.outputOptions('-af', "aformat=channel_layouts='7.1|5.1|stereo'");
                     _self.ffmpegCommand.outputOptions('-frame_duration', 60);
                     if (_self.options.downmixHeAudio && stream.channels > 3) {
                         // Downmix HE Audio

--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -377,6 +377,10 @@ class Video {
                         break;
                 }
             }
+            
+            // add hvc1 tag to codec so it is playable by Quicktime
+                
+            command.outputOptions('-tag:v', 'hvc1');
 
             // Make sure we are only attempting to use 8 bit with fallback
             // binary

--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -339,8 +339,10 @@ class Video {
             if (_self.streams.videoStreams.length > 1) {
                 // TODO implement feature
                 _self.encoder.logger.alert('More than one video stream detected. Using the video stream with the greatest duration. Assuming the second one is Cover Art masquerading as video.');
-                // copy the second stream assuming it is mjpeg Cover Art
-                command.outputOptions('-c:v:1', 'copy');
+                // copy the second stream assuming it is mjpeg Cover Art - if not mkv
+                if (args.outputFormat !== 'mkv') {
+                    command.outputOptions('-c:v:1', 'copy');
+                } 
                 videoIndex = 0;
             }
             let videoStream = _self.videoStream = _self.streams.videoStreams[videoIndex];
@@ -380,10 +382,12 @@ class Video {
                 }
             }
             
-            // add hvc1 tag to codec so it is playable by Quicktime
-                
-            command.outputOptions('-tag:v:'+ videoIndex, 'hvc1');
-
+            // add hvc1 tag to codec so it is playable by Quicktime - if not mkv
+            
+            if (args.outputFormat !== 'mkv') {
+                command.outputOptions('-tag:v:'+ videoIndex, 'hvc1');
+            }
+            
             // Make sure we are only attempting to use 8 bit with fallback
             // binary
             // TODO
@@ -705,15 +709,27 @@ class Video {
         return new Promise(function(resolve, reject) {
             
             // Video streams
-            _.each(_self.streams.videoStreams, function(stream, i) {
-                _self.ffmpegCommand.outputOptions('-map', stream.input + ':' + stream.index);
-                _self.encoder.logger.debug('Video stream', stream.input + ':' + stream.index, 'mapped.', {
-                    size: stream.width + 'x' + stream.height,
-                    codec: stream.codec_long_name,
-                    profile: stream.profile,
-                    'bit depth': _self.videoBitDepth
+            
+            if (args.outputFormat !== 'mkv') {
+                _.each(_self.streams.videoStreams, function(stream, i) {
+                    _self.ffmpegCommand.outputOptions('-map', stream.input + ':' + stream.index);
+                    _self.encoder.logger.debug('Video stream', stream.input + ':' + stream.index, 'mapped.', {
+                        size: stream.width + 'x' + stream.height,
+                        codec: stream.codec_long_name,
+                        profile: stream.profile,
+                        'bit depth': _self.videoBitDepth
+                    });
                 });
-            });
+            }
+            else {
+                _self.ffmpegCommand.outputOptions('-map', _self.videoStream.input + ':' + _self.videoStream.index);
+                _self.encoder.logger.debug('Video stream', _self.videoStream.input + ':' + _self.videoStream.index, 'mapped.', {
+                    size: _self.videoStream.width + 'x' + _self.videoStream.height,
+                    codec: _self.videoStream.codec_long_name,
+                    profile: _self.videoStream.profile,
+                    'bit depth': _self.videoBitDepth
+                });    
+            }
 
             // Handle native language detection and default audio track selection
             _.each(_self.streams.audioStreams, function(stream, i) {

--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -338,7 +338,9 @@ class Video {
 
             if (_self.streams.videoStreams.length > 1) {
                 // TODO implement feature
-                _self.encoder.logger.alert('More than one video stream detected. Using the video stream with the greatest duration.');
+                _self.encoder.logger.alert('More than one video stream detected. Using the video stream with the greatest duration. Assuming the second one is Cover Art masquerading as video.');
+                // copy the second stream assuming it is mjpeg Cover Art
+                command.outputOptions('-c:v:1', 'copy');
                 videoIndex = 0;
             }
             let videoStream = _self.videoStream = _self.streams.videoStreams[videoIndex];
@@ -380,7 +382,7 @@ class Video {
             
             // add hvc1 tag to codec so it is playable by Quicktime
                 
-            command.outputOptions('-tag:v', 'hvc1');
+            command.outputOptions('-tag:v:0', 'hvc1');
 
             // Make sure we are only attempting to use 8 bit with fallback
             // binary
@@ -701,13 +703,16 @@ class Video {
     mapStreams() {
         let _self = this;
         return new Promise(function(resolve, reject) {
-
-            _self.ffmpegCommand.outputOptions('-map', _self.videoStream.input + ':' + _self.videoStream.index);
-            _self.encoder.logger.debug('Video stream', _self.videoStream.input + ':' + _self.videoStream.index, 'mapped.', {
-                size: _self.videoStream.width + 'x' + _self.videoStream.height,
-                codec: _self.videoStream.codec_long_name,
-                profile: _self.videoStream.profile,
-                'bit depth': _self.videoBitDepth
+            
+            // Video streams
+            _.each(_self.streams.videoStreams, function(stream, i) {
+                _self.ffmpegCommand.outputOptions('-map', stream.input + ':' + stream.index);
+                _self.encoder.logger.debug('Video stream', stream.input + ':' + stream.index, 'mapped.', {
+                    size: stream.width + 'x' + stream.height,
+                    codec: stream.codec_long_name,
+                    profile: stream.profile,
+                    'bit depth': _self.videoBitDepth
+                });
             });
 
             // Handle native language detection and default audio track selection


### PR DESCRIPTION
Add hvc1 tag to codec so HEVC is playable by Quicktime in mp4 and m4v containers on MacOS. See https://danconnor.com/posts/21d8bd7c22f6ae6b423c3c09/how_to_encode_h_265_hevc_video_that_will_play_in_quicktime_on_macos_using_ffmpeg_