### PR TITLE
Make debug actually print the error when ffmpeg crashes, also fix some channel mapping stuff

### DIFF
--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -800,6 +800,9 @@ class Video {
 		    else if (stream.channels == 6) {
 			_self.ffmpegCommand.audioChannels(6).audioFilters('channelmap=channel_layout=5.1');
 		    }
+		    else if (stream.channels == 8) {
+			_self.ffmpegCommand.audioChannels(6).audioFilters('channelmap=channel_layout=7.1');
+		    }
 
                     let bitrate = _self.options.HEAudioBitrate * stream.channels;
                     _self.ffmpegCommand.outputOptions('-b:a:' + i, bitrate + 'k');

--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -797,6 +797,9 @@ class Video {
                         _self.ffmpegCommand.audioChannels(2).audioFilters('aresample=matrix_encoding=dplii');
                         stream.channels = 2;
                     }
+		    else if (stream.channels == 6) {
+			_self.ffmpegCommand.audioChannels(6).audioFilters('channelmap=channel_layout=5.1');
+		    }
 
                     let bitrate = _self.options.HEAudioBitrate * stream.channels;
                     _self.ffmpegCommand.outputOptions('-b:a:' + i, bitrate + 'k');
@@ -918,7 +921,7 @@ class Video {
                     if (err.message.startsWith('ffmpeg was killed with signal'))
                         reject(new Error('FFMPEGKILLED'));
                     else
-                        reject(new Error('ffmpeg exited with an error.'));
+                        reject(new Error('ffmpeg exited with an error.' + stdout + stderr));
                 });
             _self.ffmpegCommand.output(_self.output.path, {
                 end: true


### PR DESCRIPTION
ffmpeg has this open issue about [mapping channels correctly with libopus](https://trac.ffmpeg.org/ticket/5718).

```
[libopus @ 0x56555780a0c0] Invalid channel layout 5.1(side) for specified mapping family -1.
Error initializing output stream 0:1 -- Error while opening encoder for output stream #0:1 - maybe incorrect parameters such as bit_rate, rate, width or height
```

I suspect the correct fix for this is to have our own mappings for these but for now this PR at least let the encode continue and I figured I would open the discussion so I can fix this PR to do whatever is decided on a weekend.

ffmpeg channel maps (from `ffmpeg -layouts`):
mono: `FC`
stereo: `FL+FR`
2.1: `FL+FR+LFE`
3.0: `FL+FR+FC`
3.0(back): `FL+FR+BC`
4.0: `FL+FR+FC+BC`
quad: `FL+FR+BL+BR`
quad(side): `FL+FR+SL+SR`
3.1: `FL+FR+FC+LFE`
5.0: `FL+FR+FC+BL+BR`
5.0(side): `FL+FR+FC+SL+SR`
5.1: `FL+FR+FC+LFE+BL+BR`
5.1(side): `FL+FR+FC+LFE+SL+SR`
6.0: `FL+FR+FC+BC+SL+SR`
6.0(front): `FL+FR+FLC+FRC+SL+SR`
hexagonal: `FL+FR+FC+BL+BR+BC`
6.1: `FL+FR+FC+LFE+BC+SL+SR`
6.1(back): `FL+FR+FC+LFE+BL+BR+BC`
6.1(front): `FL+FR+LFE+FLC+FRC+SL+SR`
7.0: `FL+FR+FC+BL+BR+SL+SR`
7.0(front): `FL+FR+FC+FLC+FRC+SL+SR`
7.1: `FL+FR+FC+LFE+BL+BR+SL+SR`
7.1(wide): `FL+FR+FC+LFE+BL+BR+FLC+FRC`
7.1(wide-side): `FL+FR+FC+LFE+FLC+FRC+SL+SR`

[opus follows vorbis channel ordering](https://www.xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-800004.3.9)
stereo: `L+R`
3ch: `L+C+R`
4ch: `FL+FR+RL+RR`
5ch: `FL+C+FR+RL+RR`
5.1: `FL+C+FR+RL+RR+LFE`
6.1: `FL+C+FR+SL+SR+RC+LFE`
7.1: `FL+C+FR+SL+SR+RL+RR+LFE`

It looks like just overriding 5.1(side) to 5.1 is fine but I'm not so sure about most of the other cases