### PR TITLE
Use new (2015) syntax for setting default streams

### DIFF
--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -791,6 +791,7 @@ class Video {
                 if (stream.codec_name !== 'flac' || _self.options.forceHeAudio) {
                     _self.encoder.logger.verbose('Audio stream', colors.yellow(helpers.getStreamTitle(stream) + ' (index: ' + stream.index + ')'), 'will be encoded to HE Audio.');
                     _self.ffmpegCommand.outputOptions('-c:a:' + i, 'libopus');
+                    _self.ffmpegCommand.outputOptions('-af', "aformat=channel_layouts='7.1|5.1|stereo'");
                     _self.ffmpegCommand.outputOptions('-frame_duration', 60);
                     if (_self.options.downmixHeAudio && stream.channels > 3) {
                         // Downmix HE Audio

--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -763,7 +763,7 @@ class Video {
                     _self.encoder.logger.alert('Subtitle does not have a title. Title set to', normalizedLanguage + '.');
                     _self.ffmpegCommand.outputOptions('-metadata:s:' + stream.input + ':' + stream.index, 'title=' + normalizedLanguage);
                 }
-                _self.ffmpegCommand.outputOptions('-metadata:s:' + stream.input + ':' + stream.index, 'DISPOSITION:default=0');
+                _self.ffmpegCommand.outputOptions('-disposition:s:' + stream.index, 'default');
                 _self.encoder.logger.debug('Subtitle stream', stream.input + ':' + stream.index, 'mapped.', {
                     title: helpers.getStreamTitle(stream) || normalizedLanguage,
                     language: normalizedLanguage,

--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -731,7 +731,7 @@ class Video {
 
                 // Set default audio
                 if (_self.defaultAudioIndex && _self.defaultAudioIndex === stream.index) {
-                    _self.ffmpegCommand.outputOptions('-metadata:s:' + stream.input + ':' + stream.index, 'DISPOSITION:default=1');
+                    _self.ffmpegCommand.outputOptions('-disposition:a:' + stream.index, 'default');
                 }
 
                 let extraInfo = {

--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -761,7 +761,7 @@ class Video {
                 _self.ffmpegCommand.outputOptions('-map', stream.input + ':' + stream.index);
                 if (!helpers.getStreamTitle(stream) && _self.options.normalizeLevel >= 2) {
                     _self.encoder.logger.alert('Subtitle does not have a title. Title set to', normalizedLanguage + '.');
-                    _self.ffmpegCommand.outputOptions('-metadata:s:' + stream.input + ':' + stream.index, 'title=' + normalizedLanguage);
+                    _self.ffmpegCommand.outputOptions('-metadata:s:s:' + stream.index, 'title=' + normalizedLanguage);
                 }
                 _self.ffmpegCommand.outputOptions('-disposition:s:' + stream.index, 'default');
                 _self.encoder.logger.debug('Subtitle stream', stream.input + ':' + stream.index, 'mapped.', {


### PR DESCRIPTION
The "invalid stream specifier: #0:1" in #133 seems to be caused by using incorrect or outdated syntax for setting default tracks.

This is a WIP as I'll need to test whether the same fix is needed for default subtitles, and whether I am doing the right thing RE: track ordering.