### PR TITLE
Adding non-video/audio/subtitle streams does not work for Matroska

### DIFF
--- a/lib/classes/video.js
+++ b/lib/classes/video.js
@@ -771,11 +771,12 @@ class Video {
                 });
             });
 
-            // Other streams (Attachments: fonts, pictures, etc.)
-            _.each(_self.streams.otherStreams, function(stream, i) {
-                _self.ffmpegCommand.outputOptions('-map', stream.input + ':' + stream.index);
-                _self.encoder.logger.debug('Other stream', stream.input + ':' + stream.index, 'mapped.');
-            });
+            // "Only audio, video, and subtitles are supported for matroska"
+            // // Other streams (Attachments: fonts, pictures, etc.)
+            // _.each(_self.streams.otherStreams, function (stream, i) {
+            //     _self.ffmpegCommand.outputOptions('-map', stream.input + ':' + stream.index);
+            //     _self.encoder.logger.debug('Other stream', stream.input + ':' + stream.index, 'mapped.');
+            // });
 
             resolve();
         });


### PR DESCRIPTION
I'm not sure this is the right fix but it definitely worked for me to skip these.

I think the right thing would be to have a mapping of all the supported types for Matroska.